### PR TITLE
Simple reformatting of spec template to be closer to the rpmdev tools ruby spec template.

### DIFF
--- a/templates/fedora-17-rawhide.spec.erb
+++ b/templates/fedora-17-rawhide.spec.erb
@@ -13,10 +13,9 @@ License:    <%= spec.licenses.empty? ? "GPLv2+ or Ruby" : spec.licenses.join(" a
 URL:        <%= spec.homepage %>
 <% end -%>
 Source0:    <%= download_path %>%{gem_name}-%{version}.gem
-BuildRoot:  %{_tmppath}/%{name}-%{version}-%{release}-root-%(%{__id_u} -n)
 
 <% if spec.extensions.empty? -%>
-BuildArch:  noarch
+BuildArch:      noarch
 <% end -%>
 BuildRequires:  ruby(abi) = %{rubyabi}
 <% for req in spec.required_rubygems_version -%>
@@ -28,18 +27,18 @@ BuildRequires:  ruby <%= req %>
 <% end -%>
 Requires:       ruby(abi) = %{rubyabi}
 <% for req in spec.required_rubygems_version -%>
-Requires:   ruby(rubygems) <%= req %>
+Requires:       ruby(rubygems) <%= req %>
 <% end -%>
 <%# TODO: Unfortunatelly this do not match with ruby(abi) yet -%>
 <% for req in spec.required_ruby_version -%>
-Requires:   ruby <%= req %>
+Requires:       ruby <%= req %>
 <% end -%>
 <% for d in spec.runtime_dependencies -%>
 <% for req in d.requirement -%>
-Requires:   rubygem(<%= d.name %>) <%= req  %>
+Requires:       rubygem(<%= d.name %>) <%= req  %>
 <% end -%>
 <% end -%>
-Provides:   rubygem(%{gem_name}) = %{version}
+Provides:       rubygem(%{gem_name}) = %{version}
 
 %description
 <%= spec.description %>
@@ -73,7 +72,6 @@ gem install --local --install-dir .%{gem_dir} \
 %build
 
 %install
-rm -rf %{buildroot}
 mkdir -p %{buildroot}%{gem_dir}
 cp -a .%{gem_dir}/* \
         %{buildroot}%{gem_dir}/

--- a/templates/fedora.spec.erb
+++ b/templates/fedora.spec.erb
@@ -13,17 +13,16 @@ Version:    <%= spec.version %>
 Release:    1%{?dist}
 Summary:    <%= spec.summary.gsub(/\.$/, "") %>
 
-Group: Development/Languages
+Group:      Development/Languages
 
 License:    <%= spec.licenses.empty? ? "GPLv2+ or Ruby" : spec.licenses.join(" and ") %>
 <% if spec.homepage -%>
-URL:    <%= spec.homepage %>
+URL:        <%= spec.homepage %>
 <% end -%>
 Source0:    <%= download_path %>%{gemname}-%{version}.gem
-BuildRoot:  %{_tmppath}/%{name}-%{version}-%{release}-root-%(%{__id_u} -n)
 
 <% if spec.extensions.empty? -%>
-BuildArch:  noarch
+BuildArch:      noarch
 <% end -%>
 BuildRequires:  ruby(abi) = %{rubyabi}
 <% for req in spec.required_rubygems_version -%>
@@ -93,7 +92,6 @@ gem install --local --install-dir .%{gemdir} \
 %build
 
 %install
-rm -rf %{buildroot}
 mkdir -p %{buildroot}%{gemdir}
 cp -a .%{gemdir}/* \
         %{buildroot}%{gemdir}/


### PR DESCRIPTION
I've found that I keep editing the spec templates generated by gem2rpm to match the ordering / formatting in the rpmdev tools spec templates for every gem I package. 

These changes are purely cosmetic except for the following:
1. I added the standard BuildRoot for Fedora packages
2. Remove the %{buildroot} directory before installing to ensure nothing was left over by previous rpm builds
