### PR TITLE
Fedoraguidelines updates

### DIFF
--- a/templates/fedora-17-rawhide.spec.erb
+++ b/templates/fedora-17-rawhide.spec.erb
@@ -110,7 +110,7 @@ rm -rf %{buildroot}%{geminstdir}/ext
 %doc %{gem_instdir}/<%= f %>
 <% end -%>
 <% end -%>
-%exclude %{gem_cache}
+%{gem_cache}
 %{gem_spec}
 
 <% if doc_subpackage -%>

--- a/templates/fedora.spec.erb
+++ b/templates/fedora.spec.erb
@@ -125,7 +125,7 @@ rm -rf %{buildroot}%{geminstdir}/ext
 %doc %{geminstdir}/<%= f %>
 <% end -%>
 <% end -%>
-%exclude %{gemdir}/cache/%{gemname}-%{version}.gem
+%{gemdir}/cache/%{gemname}-%{version}.gem
 %{gemdir}/specifications/%{gemname}-%{version}.gemspec
 
 <% if doc_subpackage -%>


### PR DESCRIPTION
I've updated the fedora template files to reflect the current ruby package guidelines.  Basically moving the gem install to the %install section and removing the %exclude for the gem cache directory.
