### PR TITLE
Fix for != dependencies

### DIFF
--- a/lib/gem2rpm/helpers.rb
+++ b/lib/gem2rpm/helpers.rb
@@ -14,6 +14,9 @@ module Gem2Rpm
 	  next_version = Gem::Version.create(r.last).bump
 	  output << ['=>', r.last]
 	  output << ['<', next_version]
+        elsif r.first == '!='
+          output << ['<', r.last]
+          output << ['>', r.last]
 	else
 	  output << r
 	end


### PR DESCRIPTION
Ruby Gem supports not-equal version dependencies,  just like in sprockets-2.0.3:
  %q<tilt>, ["!= 1.3.0", "~> 1.1"]

This patch converts it into a < and > format, which is compatible with RPM spec files.
