### PR TITLE
Remove dependency on ruby

### DIFF
--- a/templates/fedora-17-rawhide.spec.erb
+++ b/templates/fedora-17-rawhide.spec.erb
@@ -16,10 +16,6 @@ Requires: ruby(abi) = %{rubyabi}
 <% for req in spec.required_rubygems_version -%>
 Requires: ruby(rubygems) <%= req %>
 <% end -%>
-<%# TODO: Unfortunatelly this do not match with ruby(abi) yet -%>
-<% for req in spec.required_ruby_version -%>
-Requires: ruby <%= req %>
-<% end -%>
 <% for d in spec.runtime_dependencies -%>
 <% for req in d.requirement -%>
 Requires: rubygem(<%= d.name %>) <%= req  %>


### PR DESCRIPTION
This commit removes the 'Requires: ruby' line from F17 and higher template, as we don't want gems to be dependent on concrete ruby implementation, but only on the ruby(abi) provided by any implementation.
