### PR TITLE
Fix fedora-19-rawhide template by escaping % in comment

### DIFF
--- a/templates/fedora-19-rawhide.spec.erb
+++ b/templates/fedora-19-rawhide.spec.erb
@@ -57,7 +57,7 @@ gem spec %{SOURCE0} -l --ruby > %{gem_name}.gemspec
 # Create the gem as gem install only works on a gem file
 gem build %{gem_name}.gemspec
 
-# %%gem_install compiles any C extensions and installs the gem into ./%gem_dir
+# %%gem_install compiles any C extensions and installs the gem into ./%%gem_dir
 # by default, so that we can move it into the buildroot in %%install
 %gem_install
 


### PR DESCRIPTION
Simple fix for the Fedora's newest template. Fix % escape as it's already fix in the guidelines[1].

[1] https://fedoraproject.org/wiki/Packaging:Ruby
