### PR TITLE
Use Gem::Specification to find gemname instead of deprecated Gem::Format

### DIFF
--- a/bin/gem2rpm
+++ b/bin/gem2rpm
@@ -109,7 +109,7 @@ gemname = nil
 srpmdir = nil
 specfile = nil
 if srpm
-    gemname = Gem::Format.from_file_by_path(gemfile).spec.name
+    gemname = Gem::Specification.find_by_path(gemfile)
     srpmdir = `/bin/mktemp -t -d gem2rpm-#{gemname}.XXXXXX`.chomp
     specfile = File::join(srpmdir, "rubygem-#{gemname}.spec")
     if output_file.nil?


### PR DESCRIPTION
-- Since Rubygems 2.0 removed Gem::Format, we can't use this class in
   code as it is throwing error when trying to create srpm
