### PR TITLE
Introduce complete file lists

### DIFF
--- a/lib/gem2rpm.rb
+++ b/lib/gem2rpm.rb
@@ -37,6 +37,7 @@ module Gem2Rpm
     format = Gem2Rpm::Format.new(package)
     spec = Gem2Rpm::Specification.new(package.spec)
     spec.description ||= spec.summary
+    config = Gem2Rpm::Configuration.instance
     download_path = ""
     unless local
       begin

--- a/lib/gem2rpm/configuration.rb
+++ b/lib/gem2rpm/configuration.rb
@@ -1,0 +1,44 @@
+require 'singleton'
+
+module Gem2Rpm
+  class Configuration
+    include Singleton
+
+    # The defaults should mostly work
+    DEFAULT_MACROS = {
+      :doc => '%doc',
+      :license => '%doc',
+      :ignore => '%ignore'
+    }
+
+    DEFAULT_RULES = {
+      :doc => [/\/?CHANGELOG.*/i, /\/?CONTRIBUTING.*/i, /\/?CONTRIBUTORS.*/i,
+                /\/?README.*/i, /\/?History.*/i, /\/?Release.*/i, /\/?doc(\/.*)?/],
+      :license => [/\/?MIT/, /\/?GPLv[0-9]+/, /\/?.*LICEN(C|S)E/, /\/?COPYING/],
+      :ignore => ['.gemtest', '.gitignore', '.travis.yml', '.yardopts', '.rvmrc'],
+      # Other files including test files that are not required for
+      # runtime and therefore currently included in -doc
+      :misc => [/.*.gemspec/, /Gemfile.*/, 'Rakefile', 'rakefile.rb', 'Vagrantfile',
+                /rspec.*/, /test(s|)/, /examples.*/]
+    }
+
+    # Hash with macros for files categories
+    def macros
+      @_macros ||= DEFAULT_MACROS
+    end
+
+    # Hash with rules for file categorization
+    def rules
+      @_rules ||= DEFAULT_RULES
+    end
+
+    def macro_for(category)
+      macros[category] ||= ''
+    end
+
+    def rule_for(category)
+      rules[category] ||= ''
+    end
+
+  end
+end

--- a/lib/gem2rpm/configuration.rb
+++ b/lib/gem2rpm/configuration.rb
@@ -8,18 +8,19 @@ module Gem2Rpm
     DEFAULT_MACROS = {
       :doc => '%doc',
       :license => '%doc',
-      :ignore => '%ignore'
+      :ignore => '%exclude'
     }
 
     DEFAULT_RULES = {
       :doc => [/\/?CHANGELOG.*/i, /\/?CONTRIBUTING.*/i, /\/?CONTRIBUTORS.*/i,
-                /\/?README.*/i, /\/?History.*/i, /\/?Release.*/i, /\/?doc(\/.*)?/],
+               /\/?AUTHORS.*/i,/\/?README.*/i, /\/?History.*/i, /\/?Release.*/i,
+               /\/?doc(\/.*)?/],
       :license => [/\/?MIT/, /\/?GPLv[0-9]+/, /\/?.*LICEN(C|S)E/, /\/?COPYING/],
       :ignore => ['.gemtest', '.gitignore', '.travis.yml', '.yardopts', '.rvmrc'],
       # Other files including test files that are not required for
       # runtime and therefore currently included in -doc
       :misc => [/.*.gemspec/, /Gemfile.*/, 'Rakefile', 'rakefile.rb', 'Vagrantfile',
-                /rspec.*/, /test(s|)/, /examples.*/]
+                /spec.*/, /rspec.*/, /test(s|)/, /examples.*/]
     }
 
     # Hash with macros for files categories

--- a/lib/gem2rpm/helpers.rb
+++ b/lib/gem2rpm/helpers.rb
@@ -40,5 +40,37 @@ module Gem2Rpm
         version == Gem::Version.new(0) ? "" : "#{op} #{version}"
       end
     end
+
+    def self.file_entries_to_rpm(entries)
+      rpm_file_list = entries.map{ |e| self.file_entry_to_rpm(e) }
+      rpm_file_list.join("\n")
+    end
+
+    def self.file_entry_to_rpm(entry)
+      config = Gem2Rpm::Configuration.instance
+      case true
+      when Gem2Rpm::Specification.doc_file?(entry)
+        "#{config.macro_for(:doc)} %{gem_instdir}/#{entry}".strip
+      when Gem2Rpm::Specification.license_file?(entry)
+        "#{config.macro_for(:license)} %{gem_instdir}/#{entry}".strip
+      when Gem2Rpm::Specification.ignore_file?(entry)
+        "#{config.macro_for(:ignore)} %{gem_instdir}/#{entry}".strip
+      else
+        "%{gem_instdir}/#{entry}"
+      end
+    end
+
+    # Returns a list of top level directories and files
+    # out of an array of file_list
+    def self.top_level_from_file_list(file_list)
+      file_list.map{ |f| f.gsub!(/([^\/]*).*/,"\\1") }.uniq
+    end
+
+    # Compares string to the given regexp conditions
+    def self.check_str_on_conditions(str, conditions)
+      conditions.any? do |condition|
+        condition.is_a?(Regexp) ? condition.match(str) : condition == str
+      end
+    end
   end
 end

--- a/templates/fedora-21-rawhide.spec.erb
+++ b/templates/fedora-21-rawhide.spec.erb
@@ -89,6 +89,10 @@ pushd .%{gem_instdir}
 
 popd
 
+<%
+# Use the new license macro
+config.macros[:license] = '%license'
+-%>
 %files
 %dir %{gem_instdir}
 <% unless spec.executables.nil? or spec.executables.empty? -%>
@@ -101,11 +105,10 @@ popd
 <% unless spec.extensions.empty? -%>
 %{gem_extdir_mri}
 <% end -%>
+<%= spec.main_file_entries %>
 <% unless doc_subpackage -%>
 %doc %{gem_docdir}
-<% for f in spec.extra_rdoc_files -%>
-%doc %{gem_instdir}/<%= f %>
-<% end -%>
+<%= spec.doc_file_entries -%>
 <% end -%>
 %exclude %{gem_cache}
 %{gem_spec}
@@ -113,9 +116,7 @@ popd
 <% if doc_subpackage -%>
 %files doc
 %doc %{gem_docdir}
-<% for f in spec.extra_rdoc_files -%>
-%doc %{gem_instdir}/<%= f %>
-<% end -%>
+<%= spec.doc_file_entries %>
 <% end # if doc_subpackage -%>
 
 %changelog


### PR DESCRIPTION
Hi,

I believe that `gem2rpm` deserves some great improvements for 2015. That means for gem2rpm to be able to generate _by default_ a buildable spec file. The prerequisite for that is to improve the listing of the files in spec files. As I already discussed with Vit, I don't like the idea of having all the logic in templates and then maintain all the possible templates like this. So what I am proposing is to have default methods for file listing that can be part of the core, can be tested etc. and default configuration (that should work for most) that can be overriden in the template (currently as singleton, ideas are welcome).

This would essentialy:
* List all the files from .gem making gem2rpm a lot more useful
* Avoid duplication in templates because the main logic stays in core
* Allow the template to override any default value or simply set its own values at the beginning (here simply as changing the Ruby hash)

It is also important to note that this does not break any backwards compatibily on its own as the templates do not use the file lists methods.

I would like to get your opinion on this and discuss the current implementation that I am proposing. Note that tests are not yet part of this PR.