### PR TITLE
Newer version of rubygems allows to bypass force

### DIFF
--- a/rubygem-gem2rpm.spec
+++ b/rubygem-gem2rpm.spec
@@ -13,8 +13,8 @@ License: GPLv2+ or Ruby
 URL: http://rubyforge.org/projects/gem2rpm/
 Source0: http://gems.rubyforge.org/gems/%{gemname}-%{version}.gem
 BuildRoot: %{_tmppath}/%{name}-%{version}-%{release}-root-%(%{__id_u} -n)
-Requires: rubygems
-BuildRequires: rubygems
+Requires: rubygems >= 2.4
+BuildRequires: rubygems >= 2.4
 BuildArch: noarch
 Provides: rubygem(%{gemname}) = %{version}
 

--- a/templates/default.spec.erb
+++ b/templates/default.spec.erb
@@ -41,7 +41,7 @@ Provides: ruby(<%= spec.name.capitalize %>) = %{version}
 %install
 %{__rm} -rf %{buildroot}
 mkdir -p %{gembuilddir}
-gem install --local --install-dir %{gembuilddir} --force %{SOURCE0}
+gem install --local --build-dir %{gembuilddir} %{SOURCE0}
 <% if ! spec.executables.empty? -%>
 mkdir -p %{buildroot}/%{_bindir}
 mv %{gembuilddir}/bin/* %{buildroot}/%{_bindir}


### PR DESCRIPTION
This has not been tested in respect to this project.
I used this project as a very helpful guidline in building RPMs and wanted to share what I learned.
I was unhappy with the need need to use the --force flag and found that in rubgems 2.4 --build-root was added
Hope this helps. Thanks for the information that this repo has provided me.