### PR TITLE
Add new feature to specify a output directory.

### DIFF
--- a/bin/gem2rpm
+++ b/bin/gem2rpm
@@ -25,17 +25,22 @@ if options[:print_template_file]
 end
 
 if rest.size != 1
-  $stderr.puts "Missing GEMFILE\n\n"
-  $stderr.puts opts
+  Gem2Rpm.show_message('Missing GEMFILE', options)
   exit(1)
 end
 gemfile = rest[0]
+out_dir = options[:directory]
+unless Dir.exist?(out_dir)
+  Gem2Rpm.show_message('No such directory', options)
+  exit(1)
+end
 
 if options[:fetch]
   gem_uri = ''
   open("https://rubygems.org/api/v1/gems/#{gemfile}.json") do |f|
     gem_uri = f.read.match(/"gem_uri":\s*"(.*?)",/m)[1]
     gemfile = URI.parse(gem_uri).path.split('/').last
+    gemfile = File.join(out_dir, gemfile)
     open(gemfile, 'w') do |gf|
       gf.write(open(gem_uri).read)
     end
@@ -68,7 +73,7 @@ if options[:srpm]
   FileUtils.copy(options[:output_file], specfile) unless File.exist?(specfile)
   FileUtils.copy(gemfile, srpmdir)
 
-  system("rpmbuild -bs --nodeps --define '_sourcedir #{srpmdir}' --define '_srcrpmdir #{Dir.pwd}' #{specfile}")
+  system("rpmbuild -bs --nodeps --define '_sourcedir #{srpmdir}' --define '_srcrpmdir #{out_dir}' #{specfile}")
 end
 
 Gem2Rpm.print_dependencies(gemfile) if options[:deps]

--- a/lib/gem2rpm.rb
+++ b/lib/gem2rpm.rb
@@ -23,6 +23,11 @@ module Gem2Rpm
       'r'
     end
 
+  def self.show_message(message, obj = nil, out = $stderr)
+    out.puts("#{message}\n\n")
+    out.puts obj if obj
+  end
+
   def self.find_download_url(name, version)
     dep = Gem::Dependency.new(name, "=#{version}")
     fetcher = Gem2Rpm::SpecFetcher.new(Gem::SpecFetcher.fetcher)

--- a/lib/gem2rpm/configuration.rb
+++ b/lib/gem2rpm/configuration.rb
@@ -4,6 +4,8 @@ module Gem2Rpm
   class Configuration
     include Singleton
 
+    CURRENT_DIR = Dir.pwd
+
     DEFAULT_OPTIONS = {
       :print_template_file => nil,
       :template_file => nil,
@@ -14,6 +16,7 @@ module Gem2Rpm
       :nongem => false,
       :doc_subpackage => true,
       :fetch => false,
+      :directory => CURRENT_DIR,
     }
 
     # The defaults should mostly work
@@ -190,6 +193,10 @@ module Gem2Rpm
 
       parser.on('--fetch', 'Fetch the gem from rubygems.org') do
         options[:fetch] = true
+      end
+
+      parser.on('-C', '--directory DIR', 'Change to directory DIR') do |val|
+        options[:directory] = val
       end
 
       parser.separator('')

--- a/test/test_gem2rpm.rb
+++ b/test/test_gem2rpm.rb
@@ -20,6 +20,23 @@ class TestGem2Rpm < Minitest::Test
     end
   end
 
+  def test_show_message_for_message
+    expected = <<-'END'
+foo
+
+    END
+
+    Gem2Rpm.show_message("foo", nil, @out)
+    assert_equal expected, @out.string
+  end
+
+  def test_show_message_for_obj
+    obj = 'bar'
+    Gem2Rpm.show_message("foo", obj, @out)
+    assert_equal("foo\n\nbar\n", @out.string)
+  end
+
+
   # TODO: Make this test work offline.
   def test_find_download_url_for_source_address
     assert_match %r{https?://rubygems.org/gems/}, Gem2Rpm.find_download_url("gem2rpm", "0.8.0")


### PR DESCRIPTION
Hi, I implemented new feature to specify the output directory for gem and src.rpm file for below request.
https://github.com/fedora-ruby/gem2rpm/issues/60

Could you merge to your master branch?

$ gem2rpm --fetch --srpm -C /tmp/foo gem2rpm
Wrote: /tmp/foo/rubygem-gem2rpm-0.11.3-1.fc23.src.rpm
$ ls /tmp/foo/
gem2rpm-0.11.3.gem  rubygem-gem2rpm-0.11.3-1.fc23.src.rpm

Thanks.
