### PR TITLE
Add gem package file validation check.

### DIFF
--- a/bin/gem2rpm
+++ b/bin/gem2rpm
@@ -47,6 +47,10 @@ if options[:fetch]
   end
 end
 
+unless File.exist?(gemfile)
+  Gem2Rpm.show_message('Invalid GEMFILE', options)
+  exit(1)
+end
 srpmdir = nil
 specfile = nil
 if options[:srpm]


### PR DESCRIPTION
Right now below command throws the exception.
$ gem2rpm --srpm gem2rpm

1st argument is gem name with --fetch option, but otherwise gem file.
This specification causes user to mistake the command.

So, I added gem package file validation check for all the options cases.

$ gem2rpm --srpm gem2rpm
Invalid GEMFILE

{:print_template_file=>nil, :template_file=>nil, :output_file=>nil, :local=>false, :srpm=>true, :deps=>false, :nongem=>false, :doc_subpackage=>true, :fetch=>false, :directory=>nil, :args=>["gem2rpm"]}

$ gem2rpm --dependencies gem2rpm
Invalid GEMFILE

{:print_template_file=>nil, :template_file=>nil, :output_file=>nil, :local=>false, :srpm=>false, :deps=>true, :nongem=>false, :doc_subpackage=>true, :fetch=>false, :directory=>"/home/jaruga/git/gem2rpm_jaruga", :args=>["gem2rpm"]}

Could you merge this modification to your master branch?
Thanks.