### PR TITLE
Add error checking for rpmbuild command

### DIFF
--- a/bin/gem2rpm
+++ b/bin/gem2rpm
@@ -77,7 +77,12 @@ if options[:srpm]
   FileUtils.copy(options[:output_file], specfile) unless File.exist?(specfile)
   FileUtils.copy(gemfile, srpmdir)
 
-  system("rpmbuild -bs --nodeps --define '_sourcedir #{srpmdir}' --define '_srcrpmdir #{out_dir}' #{specfile}")
+  command = "rpmbuild -bs --nodeps --define '_sourcedir #{srpmdir}' " +
+    "--define '_srcrpmdir #{out_dir}' #{specfile}"
+  unless system(command)
+    Gem2Rpm.show_message("Command failed: #{command}")
+    exit(1)
+  end
 end
 
 Gem2Rpm.print_dependencies(gemfile) if options[:deps]


### PR DESCRIPTION
I found rpmbuild command's exit status was not checked in the bin/gem2rpm.
If rpmbuild command fails, bin/gem2rpm should exit as non-zero status.

```
$ bin/gem2rpm -s test/artifacts/testing_gem/testing_gem-1.0.0.gem
error: line 9: Empty tag: License:
$ echo $?
0
```

Could you check it?

I am going to add a gem file with correct format for testing in another pull-request.