### PR TITLE
Add TESTOPTS=-v to for Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,4 +5,4 @@ rvm:
   - "2.1.4"
   - "2.2.0"
   - "ruby-head"
-script: rake
+script: rake TESTOPTS='-v'


### PR DESCRIPTION
This feature is to display the message with verbose mode.
Because we may want to see the detail message to see skipped actual test cases on Travis.

It is cut out from below pull-request,  because we may like a small mass of the feature and commit.
https://github.com/fedora-ruby/gem2rpm/pull/72

Ref: TESTOPTS
http://rake.rubyforge.org/classes/Rake/TestTask.html