### PR TITLE
Fix bug for exist? method on Ruby 1.8

### DIFF
--- a/bin/gem2rpm
+++ b/bin/gem2rpm
@@ -30,7 +30,7 @@ if rest.size != 1
 end
 gemfile = rest[0]
 out_dir = options[:directory]
-unless Dir.exist?(out_dir)
+unless File.directory?(out_dir)
   Gem2Rpm.show_message("No such directory #{out_dir}")
   exit(1)
 end


### PR DESCRIPTION
I fixed the bug on Ruby 1.8 environment.
It is cut out from below pull-request, because we may like a small mass of the feature and commit.
https://github.com/fedora-ruby/gem2rpm/pull/72

```
$ ruby -v
ruby 1.8.7 (2013-06-27 patchlevel 374) [x86_64-linux]

$ bin/gem2rpm gem2rpm-0.11.3.gem
bin/gem2rpm:33: undefined method `exist?' for Dir:Class (NoMethodError)
```
