### PR TITLE
Remove exit method from files in lib and add logic in bin/gem2rpm.

### DIFF
--- a/bin/gem2rpm
+++ b/bin/gem2rpm
@@ -9,7 +9,21 @@ require 'fileutils'
 require 'open-uri'
 require 'uri'
 
-options = Gem2Rpm::Configuration.instance.options
+options = begin
+  Gem2Rpm::Configuration.instance.options
+rescue Gem2Rpm::Configuration::InvalidOption => e
+  Gem2Rpm.show_message(e)
+  exit(1)
+end
+if options[:templates]
+  Gem2Rpm.show_templates
+  exit(0)
+end
+if options[:version]
+  Gem2Rpm.show_version
+  exit(0)
+end
+
 rest = options[:args]
 
 template = begin

--- a/lib/gem2rpm.rb
+++ b/lib/gem2rpm.rb
@@ -28,6 +28,18 @@ module Gem2Rpm
     out.puts obj if obj
   end
 
+  def self.show_templates(out = $stdout)
+    out.puts "Available templates in #{Gem2Rpm::Template.default_location}:\n\n"
+    template_list = Gem2Rpm::Template.list.map do |t|
+      t.gsub(/(.*)\.spec.erb/, '\\1')
+    end.join("\n")
+    out.puts template_list
+  end
+
+  def self.show_version(out = $stdout)
+    out.puts Gem2Rpm::VERSION
+  end
+
   def self.find_download_url(name, version)
     dep = Gem::Dependency.new(name, "=#{version}")
     fetcher = Gem2Rpm::SpecFetcher.new(Gem::SpecFetcher.fetcher)

--- a/lib/gem2rpm/configuration.rb
+++ b/lib/gem2rpm/configuration.rb
@@ -4,11 +4,15 @@ module Gem2Rpm
   class Configuration
     include Singleton
 
+    class InvalidOption < Exception; end
+
     CURRENT_DIR = Dir.pwd
 
     DEFAULT_OPTIONS = {
       :print_template_file => nil,
       :template_file => nil,
+      :templates => false,
+      :version => false,
       :output_file => nil,
       :local => false,
       :srpm => false,
@@ -115,9 +119,8 @@ module Gem2Rpm
       @options[:args] = args
     # TODO: Refactor, this is probably not the best palce.
     rescue OptionParser::InvalidOption => e
-      $stderr.puts "#{e}\n\n"
-      $stderr.puts parser
-      exit(1)
+      message = "#{e}\n\n#{parser}\n"
+      fail(InvalidOption, message)
     end
 
     # Creates an option parser.
@@ -151,20 +154,12 @@ module Gem2Rpm
         options[:template_file] = val
       end
 
-      # TODO: This does not belong here.
       parser.on('--templates', 'List all available templates') do
-        puts "Available templates in #{Gem2Rpm::Template.default_location}:\n\n"
-        template_list = Gem2Rpm::Template.list.map do |t|
-          t.gsub(/(.*)\.spec.erb/, '\\1')
-        end.join("\n")
-        puts template_list
-        exit 0
+        options[:templates] = true
       end
 
-      # TODO: This does not belong here.
       parser.on('-v', '--version', 'Print gem2rpm\'s version and exit') do
-        puts Gem2Rpm::VERSION
-        exit 0
+        options[:version] = true
       end
 
       parser.on('-o', '--output FILE', 'Send the specfile to FILE') do |val|

--- a/test/test_configuration.rb
+++ b/test/test_configuration.rb
@@ -12,7 +12,34 @@ class TestConfiguration < Minitest::Test
   end
 
   def test_options
+    setup_options
     assert @config.options
     assert_includes @config.options, :args
+  end
+
+  def test_option_templates
+    setup_options('--templates')
+    assert(@config.options)
+    assert_includes(@config.options, :templates)
+  end
+
+  def test_option_version
+    setup_options('-v')
+    assert(@config.options)
+    assert_includes(@config.options, :version)
+  end
+
+  def test_invalid_option
+    e = assert_raises(Gem2Rpm::Configuration::InvalidOption) do
+      setup_options('-Z')
+    end
+    assert_match(/\Ainvalid option: -Z\n\nUsage:/m, e.to_s)
+  end
+
+  private
+
+  def setup_options(string = '')
+    argv = string.split
+    @config.send(:handle_options, argv)
   end
 end

--- a/test/test_gem2rpm.rb
+++ b/test/test_gem2rpm.rb
@@ -36,6 +36,18 @@ foo
     assert_equal("foo\n\nbar\n", @out.string)
   end
 
+  def test_show_templates
+    Gem2Rpm.show_templates(@out)
+    assert_match(/^Available templates/, @out.string)
+    assert_match(/\AAvailable templates.*\npld\n\Z/m, @out.string)
+  end
+
+  def test_show_version
+    Gem2Rpm.show_version(@out)
+    assert_match(/^\d/, @out.string)
+    assert_equal("#{Gem2Rpm::VERSION}\n", @out.string)
+  end
+
   def test_find_download_url_for_source_address
     skip_if_offline
 


### PR DESCRIPTION
I modified the code to fix the issue [1], by the idea based on your idea [2].

The reason why I selected to use "show_templates", "show_version" is that we have already had show_message method to print message to out stream.

Could you check and merge to this modification?
Thanks.

[1] https://github.com/fedora-ruby/gem2rpm/issues/74
[2] https://github.com/fedora-ruby/gem2rpm/pull/75
