### PR TITLE
Add blank string to URL tag if homepage is empty.

### DIFF
--- a/lib/gem2rpm/specification.rb
+++ b/lib/gem2rpm/specification.rb
@@ -5,12 +5,21 @@ require 'gem2rpm/helpers'
 
 module Gem2Rpm
   class Specification < SimpleDelegator
+    BLANK_RE = /\A[[:space:]]*\z/
+
     # A long description of gem wrapped to 78 characters.
     def description
       d = super.to_s.chomp
       d = summary.to_s.chomp if d.empty?
       d.gsub!(/([^.!?])\Z/, "\\1.")
       Helpers.word_wrap(d, 78) + "\n"
+    end
+
+    # The URL of this gem's home page
+    def homepage
+      h = super
+      h = nil if h && BLANK_RE =~ h
+      h
     end
 
     # A list of Gem::Dependency objects this gem depends on (includes every

--- a/test/test_specification.rb
+++ b/test/test_specification.rb
@@ -40,4 +40,24 @@ class TestSpecification < Minitest::Test
     @gemspec.summary = "summary"
     assert_equal "summary.\n", @spec.description
   end
+
+  def test_homepage
+    @gemspec.homepage = 'https://github.com/fedora-ruby/testing'
+    assert_equal @gemspec.homepage, @spec.homepage
+  end
+
+  def test_homepage_nil
+    @gemspec.homepage = nil
+    assert_nil @spec.homepage
+  end
+
+  def test_homepage_empty
+    @gemspec.homepage = ''
+    assert_nil @spec.homepage
+  end
+
+  def test_homepage_blank
+    @gemspec.homepage = ' '
+    assert_nil @spec.homepage
+  end
 end


### PR DESCRIPTION
Fix for https://github.com/fedora-ruby/gem2rpm/issues/71
Add blank string to URL tag if homepage is empty.

## Highlight
- Modified templates. Right now only 2 templates. If you will accept this, I will update other templates as well, and push one more commit on this branch. Finally unify commits to 1 commit by rebase.
- Added gem file for testing empty tag.

