### PR TITLE
use '>=' not '=>' in specs

### DIFF
--- a/lib/gem2rpm/helpers.rb
+++ b/lib/gem2rpm/helpers.rb
@@ -24,7 +24,7 @@ module Gem2Rpm
     # '<' pair.
     def self.expand_pessimistic_requirement(requirement)
       next_version = Gem::Version.create(requirement.last).bump
-      return ['=>', requirement.last], ['<', next_version]
+      return ['>=', requirement.last], ['<', next_version]
     end
 
     # Expands the not equal version operator '!=' into equivalent '<' and

--- a/test/test_helpers.rb
+++ b/test/test_helpers.rb
@@ -19,12 +19,12 @@ class TestHelpers < Minitest::Test
 
   def test_first_level_pessimistic_version_constraint
     r = Gem::Requirement.new(["~> 1.2"])
-    assert_equal(["=> 1.2", "< 2"], Gem2Rpm::Helpers.requirement_versions_to_rpm(r))
+    assert_equal([">= 1.2", "< 2"], Gem2Rpm::Helpers.requirement_versions_to_rpm(r))
   end
 
   def test_second_level_pessimistic_version_constraint
     r = Gem::Requirement.new(["~> 1.2.3"])
-    assert_equal(["=> 1.2.3", "< 1.3"], Gem2Rpm::Helpers.requirement_versions_to_rpm(r))
+    assert_equal([">= 1.2.3", "< 1.3"], Gem2Rpm::Helpers.requirement_versions_to_rpm(r))
   end
 
   def test_pessimistic_version_constraint_with_trailing_text
@@ -33,12 +33,12 @@ class TestHelpers < Minitest::Test
     return if gem_version >= Gem::Version.create("1.3.2")
 
     r = Gem::Requirement.new(["~> 1.2.3.beta.8"])
-    assert_equal(["=> 1.2.3.beta.8", "< 1.3"], Gem2Rpm::Helpers.requirement_versions_to_rpm(r))
+    assert_equal([">= 1.2.3.beta.8", "< 1.3"], Gem2Rpm::Helpers.requirement_versions_to_rpm(r))
   end
 
   def test_second_level_pessimistic_version_constraint_with_two_digit_version
     r = Gem::Requirement.new(["~> 1.12.3"])
-    assert_equal(["=> 1.12.3", "< 1.13"], Gem2Rpm::Helpers.requirement_versions_to_rpm(r))
+    assert_equal([">= 1.12.3", "< 1.13"], Gem2Rpm::Helpers.requirement_versions_to_rpm(r))
   end
 
   def test_first_level_not_equal_version_constraint


### PR DESCRIPTION
this is more rpm like version range specifier style

it's old patch i used in pld
https://github.com/pld-linux/gem2rpm/commits/auto/th/gem2rpm-0.11.2-1/style.patch