### PR TITLE
Convert 2 empty lines to 1 empty line.

### DIFF
--- a/templates/fedora-27-rawhide.spec.erb
+++ b/templates/fedora-27-rawhide.spec.erb
@@ -30,9 +30,9 @@ BuildArch: noarch
 <% end -%>
 
 %description
-<%= spec.description %>
-
+<%= spec.description -%>
 <% if doc_subpackage -%>
+
 %package doc
 Summary: Documentation for %{name}
 Requires: %{name} = %{version}-%{release}
@@ -57,18 +57,18 @@ gem build ../%{gem_name}-%{version}.gemspec
 mkdir -p %{buildroot}%{gem_dir}
 cp -a .%{gem_dir}/* \
         %{buildroot}%{gem_dir}/
-
 <% unless spec.extensions.empty? -%>
+
 mkdir -p %{buildroot}%{gem_extdir_mri}
 cp -a .%{gem_extdir_mri}/{gem.build_complete,*.so} %{buildroot}%{gem_extdir_mri}/
-
 <% for ext in spec.extensions -%>
+
 # Prevent dangling symlink in -debuginfo (rhbz#878863).
 rm -rf %{buildroot}%{gem_instdir}/<%= ext.split(File::SEPARATOR).first %>/
 <% end -%>
 <% end -%>
-
 <% unless spec.executables.empty? -%>
+
 mkdir -p %{buildroot}%{_bindir}
 cp -a .%{_bindir}/* \
         %{buildroot}%{_bindir}/


### PR DESCRIPTION
This PR fixes #104 .

According to [the ERB syntax](https://puppet.com/docs/puppet/5.5/lang_template_erb.html
), `-%>` is to trim the following line break if the tag ends a line.

## Test

I tested the PR in 2 cases (1. `spec.extensions` is empty, 2. `spec.extensions` is not empty).

```
$ pwd
/home/jaruga/git/gem2rpm
```

### With rack-2.2.3.gem (`spec.extensions` is empty)

```
$ bin/gem2rpm rack-2.2.3.gem 
# Generated from rack-2.2.3.gem by gem2rpm -*- rpm-spec -*-
%global gem_name rack

Name: rubygem-%{gem_name}
Version: 2.2.3
Release: 1%{?dist}
Summary: A modular Ruby webserver interface
License: MIT
URL: https://github.com/rack/rack
Source0: https://rubygems.org/gems/%{gem_name}-%{version}.gem
BuildRequires: ruby(release)
BuildRequires: rubygems-devel
BuildRequires: ruby >= 2.3.0
# BuildRequires: rubygem(minitest) >= 5.0
# BuildRequires: rubygem(minitest) < 6
# BuildRequires: rubygem(minitest-sprint)
# BuildRequires: rubygem(minitest-global_expectations)
BuildArch: noarch

%description
Rack provides a minimal, modular and adaptable interface for developing
web applications in Ruby. By wrapping HTTP requests and responses in
the simplest way possible, it unifies and distills the API for web
servers, web frameworks, and software in between (the so-called
middleware) into a single method call.

%package doc
Summary: Documentation for %{name}
Requires: %{name} = %{version}-%{release}
BuildArch: noarch

%description doc
Documentation for %{name}.

%prep
%setup -q -n %{gem_name}-%{version}

%build
# Create the gem as gem install only works on a gem file
gem build ../%{gem_name}-%{version}.gemspec

# %%gem_install compiles any C extensions and installs the gem into ./%%gem_dir
# by default, so that we can move it into the buildroot in %%install
%gem_install

%install
mkdir -p %{buildroot}%{gem_dir}
cp -a .%{gem_dir}/* \
        %{buildroot}%{gem_dir}/

mkdir -p %{buildroot}%{_bindir}
cp -a .%{_bindir}/* \
        %{buildroot}%{_bindir}/

find %{buildroot}%{gem_instdir}/bin -type f | xargs chmod a+x

%check
pushd .%{gem_instdir}
# ruby -e 'Dir.glob "./test/**/*_test.rb", &method(:require)'
popd

%files
%dir %{gem_instdir}
%{_bindir}/rackup
%license %{gem_instdir}/MIT-LICENSE
%{gem_instdir}/bin
%{gem_instdir}/contrib
%{gem_instdir}/example
%{gem_libdir}
%exclude %{gem_cache}
%{gem_spec}

%files doc
%doc %{gem_docdir}
%doc %{gem_instdir}/CHANGELOG.md
%doc %{gem_instdir}/CONTRIBUTING.md
%doc %{gem_instdir}/README.rdoc
%{gem_instdir}/Rakefile
%doc %{gem_instdir}/SPEC.rdoc
%{gem_instdir}/rack.gemspec

%changelog
* Fri Jan 08 2021 Jun Aruga <jaruga@redhat.com> - 2.2.3-1
- Initial package
```

### With nio4r-2.5.4.gem (`spec.extensions` is not empty)

```
$ bin/gem2rpm nio4r-2.5.4.gem 
# Generated from nio4r-2.5.4.gem by gem2rpm -*- rpm-spec -*-
%global gem_name nio4r

Name: rubygem-%{gem_name}
Version: 2.5.4
Release: 1%{?dist}
Summary: New IO for Ruby
License: MIT
URL: https://github.com/socketry/nio4r
Source0: https://rubygems.org/gems/%{gem_name}-%{version}.gem
BuildRequires: ruby(release)
BuildRequires: rubygems-devel
BuildRequires: ruby-devel >= 2.4
# Compiler is required for build of gem binary extension.
# https://fedoraproject.org/wiki/Packaging:C_and_C++#BuildRequires_and_Requires
BuildRequires: gcc

%description
Cross-platform asynchronous I/O primitives for scalable network clients and
servers. Inspired by the Java NIO API, but simplified for ease-of-use.

%package doc
Summary: Documentation for %{name}
Requires: %{name} = %{version}-%{release}
BuildArch: noarch

%description doc
Documentation for %{name}.

%prep
%setup -q -n %{gem_name}-%{version}

%build
# Create the gem as gem install only works on a gem file
gem build ../%{gem_name}-%{version}.gemspec

# %%gem_install compiles any C extensions and installs the gem into ./%%gem_dir
# by default, so that we can move it into the buildroot in %%install
%gem_install

%install
mkdir -p %{buildroot}%{gem_dir}
cp -a .%{gem_dir}/* \
        %{buildroot}%{gem_dir}/

mkdir -p %{buildroot}%{gem_extdir_mri}
cp -a .%{gem_extdir_mri}/{gem.build_complete,*.so} %{buildroot}%{gem_extdir_mri}/

# Prevent dangling symlink in -debuginfo (rhbz#878863).
rm -rf %{buildroot}%{gem_instdir}/ext/

%check
pushd .%{gem_instdir}
# Run the test suite.
popd

%files
%dir %{gem_instdir}
%{gem_extdir_mri}
%{gem_instdir}/.github
%exclude %{gem_instdir}/.gitignore
%exclude %{gem_instdir}/.rubocop.yml
%{gem_instdir}/CHANGES.md
%{gem_libdir}
%{gem_instdir}/logo.png
%{gem_instdir}/rakelib
%exclude %{gem_cache}
%{gem_spec}

%files doc
%doc %{gem_docdir}
%exclude %{gem_instdir}/.rspec
%{gem_instdir}/Gemfile
%doc %{gem_instdir}/README.md
%{gem_instdir}/Rakefile
%{gem_instdir}/examples
%{gem_instdir}/nio4r.gemspec
%{gem_instdir}/spec

%changelog
* Fri Jan 08 2021 Jun Aruga <jaruga@redhat.com> - 2.5.4-1
- Initial package
```

