### PR TITLE
Add more files to ignore and doc

### DIFF
--- a/lib/gem2rpm/configuration.rb
+++ b/lib/gem2rpm/configuration.rb
@@ -36,14 +36,18 @@ module Gem2Rpm
     DEFAULT_RULES = {
       :doc => [
         /\/?CHANGELOG.*/i,
+        /\/?CHANGES.*/i,
         /\/?CONTRIBUTING.*/i,
         /\/?CONTRIBUTORS.*/i,
         /\/?AUTHORS.*/i,
         /\/?README.*/i,
         /\/?History.*/i,
         /\/?Release.*/i,
+        /\/?SECURITY.*/i,
         /\/?doc(\/.*)?/,
+        'Appraisals',
         'NEWS',
+        'TODO',
       ],
       :license => [
         /\/?MIT/,
@@ -54,6 +58,7 @@ module Gem2Rpm
       :ignore => [
         '.gemtest',
         '.gitignore',
+        '.github',
         '.travis.yml',
         '.hound.yml',
         '.yardopts',
@@ -61,7 +66,11 @@ module Gem2Rpm
         '.rvmrc',
         '.rubocop.yml',
         '.rubocop_todo.yml',
+        '.ruby-version',
         /^\..*rc$/i,
+        'appveyor.yml',
+        'coveralls.yml',
+        'Guardfile',
       ],
       :test => [
         '.rspec',


### PR DESCRIPTION
These are some files the Foreman project has found in various gems which are common.

appveyor.yml is configuration for https://www.appveyor.com/
coveralls.yml is configuration for https://coveralls.io/

Both are only used in CI pipelines and don't make sense in RPMs.

.github is configuration for various Github related matters. Technically this can contain CONTRIBUTING.md so it's not perfect. The alternative is only exclude .github/workflows to exclude Github Actions, but we found that it's generally not a problem to exclude .github.