### PR TITLE
Introduce a template context for proper loading

### DIFF
--- a/lib/gem2rpm/context.rb
+++ b/lib/gem2rpm/context.rb
@@ -1,0 +1,54 @@
+require 'gem2rpm/template_helpers'
+
+module Gem2Rpm
+  class Context
+    include Gem2Rpm::TemplateHelpers
+
+    attr_reader :nongem, :local, :doc_subpackage, :package, :format, :spec,
+      :config, :runtime_dependencies, :development_dependencies, :tests,
+      :files, :download_path
+
+    def initialize(fname, nongem = true, local = false, doc_subpackage = true)
+      @nongem = nongem
+      @local = local
+      @doc_subpackage = doc_subpackage
+
+      @package = Gem2Rpm::Package.new(fname)
+      # Deprecate, kept just for backward compatibility.
+      @format = Gem2Rpm::Format.new(@package)
+      @spec = Gem2Rpm::Specification.new(@package.spec)
+
+      @config = Configuration.instance.reset
+
+      @runtime_dependencies = Gem2Rpm::RpmDependencyList.new(@spec.runtime_dependencies)
+      @development_dependencies = Gem2Rpm::RpmDependencyList.new(@spec.development_dependencies)
+
+      @tests = TestSuite.new(spec)
+
+      # Ruby 2.0 doesn't have sorted files
+      @files = RpmFileList.new(spec.files.sort)
+
+      @download_path = ""
+      unless @local
+        begin
+          @download_path = Gem2Rpm.find_download_url(@spec.name, @spec.version)
+        rescue DownloadUrlError => e
+          $stderr.puts "Warning: Could not retrieve full URL for #{@spec.name}\nWarning: Edit the specfile and enter the full download URL as 'Source0' manually"
+          $stderr.puts e.inspect
+        end
+      end
+    end
+
+    def main_files
+      @files.top_level_entries.main_entries
+    end
+
+    def doc_files
+      @files.top_level_entries.doc_entries
+    end
+
+    def packager
+      Gem2Rpm.packager
+    end
+  end
+end

--- a/lib/gem2rpm/rpm_dependency.rb
+++ b/lib/gem2rpm/rpm_dependency.rb
@@ -1,3 +1,5 @@
+require 'gem2rpm/gem/dependency'
+
 module Gem2Rpm
   class RpmDependency < Gem2Rpm::Dependency
     def initialize(dependency)

--- a/test/templates/fake_files/config-override.erb
+++ b/test/templates/fake_files/config-override.erb
@@ -1,0 +1,11 @@
+<%-
+# Move runtime to the doc subpackage
+config.rules[:misc] << 'runtime'
+# %exclude Gemfile
+config.rules[:ignore] << 'Gemfile'
+-%>
+%files
+<%= main_files.to_rpm %>
+
+%files doc
+<%= doc_files.to_rpm %>

--- a/test/templates/test_config_override.rb
+++ b/test/templates/test_config_override.rb
@@ -1,0 +1,25 @@
+require 'helper'
+
+class TestConfigOverride < Minitest::Test
+  def test_rules_respected
+    template = Gem2Rpm::Template.new(File.join(__dir__, 'fake_files', 'config-override.erb'))
+    out = StringIO.new
+    Gem2Rpm.convert(gem_path, template, out, false)
+
+    expected = <<-EXPECTED.gsub(/^ */, '')
+    %files
+    %exclude %{gem_instdir}/.travis.yml
+    %{gem_instdir}/exe
+    %{gem_instdir}/ext
+    %{gem_libdir}
+
+    %files doc
+    %exclude %{gem_instdir}/Gemfile
+    %doc %{gem_instdir}/README
+    %{gem_instdir}/Rakefile
+    %{gem_instdir}/runtime
+    %{gem_instdir}/testing_gem.gemspec
+    EXPECTED
+    assert_equal(expected, out.string)
+  end
+end

--- a/test/test_template_helpers.rb
+++ b/test/test_template_helpers.rb
@@ -1,13 +1,17 @@
 require 'helper'
 require 'gem2rpm/template_helpers'
 
+class ConcreteTemplateHelpers
+  extend Gem2Rpm::TemplateHelpers
+end
+
 class TestTemplateHelpers < Minitest::Test
   def test_requirement
-    assert_equal "rubygem(foo)", Gem2Rpm.requirement("rubygem(foo)")
-    assert_equal "rubygem(foo) >= 1.0", Gem2Rpm.requirement("rubygem(foo)", ">= 1.0")
-    assert_equal "rubygem(foo)", Gem2Rpm.requirement("rubygem(foo)", "")
+    assert_equal "rubygem(foo)", ConcreteTemplateHelpers.requirement("rubygem(foo)")
+    assert_equal "rubygem(foo) >= 1.0", ConcreteTemplateHelpers.requirement("rubygem(foo)", ">= 1.0")
+    assert_equal "rubygem(foo)", ConcreteTemplateHelpers.requirement("rubygem(foo)", "")
 
     artificial_object = Object.new
-    assert_equal "rubygem(foo)", Gem2Rpm.requirement("rubygem(foo)", artificial_object)
+    assert_equal "rubygem(foo)", ConcreteTemplateHelpers.requirement("rubygem(foo)", artificial_object)
   end
 end


### PR DESCRIPTION
It is possible to provide config rules inside a template. However, since main_files and doc_files are calculated before the template is loaded this is ignored. By adding these as methods on an instance they are calculated lazily without needing to change anything in the templates.

Fixes #115