### PR TITLE
Use `gem_path` helper to ensure testing gem is available.

### DIFF
--- a/test/test_gem2rpm.rb
+++ b/test/test_gem2rpm.rb
@@ -66,10 +66,7 @@ foo
       rubygem(test_development) >= 1.0.0
     END
 
-    Gem2Rpm.print_dependencies(
-      File.join(File.dirname(__FILE__), 'artifacts', 'testing_gem', 'testing_gem-1.0.0.gem'),
-      @out
-    )
+    Gem2Rpm.print_dependencies(gem_path, @out)
 
     assert_equal dependencies, @out.string.lines.sort
   end


### PR DESCRIPTION
This prevents error which randomly happend depending on test order:

~~~
  1) Error:
TestGem2Rpm#test_print_dependencies:
Gem::Package::FormatError: No such file or directory @ rb_sysopen - /home/runner/work/gem2rpm/gem2rpm/test/artifacts/testing_gem/testing_gem-1.0.0.gem
    /opt/hostedtoolcache/Ruby/3.1.2/x64/lib/ruby/3.1.0/rubygems/package.rb:611:in `rescue in verify'
    /opt/hostedtoolcache/Ruby/3.1.2/x64/lib/ruby/3.1.0/rubygems/package.rb:588:in `verify'
    /opt/hostedtoolcache/Ruby/3.1.2/x64/lib/ruby/3.1.0/rubygems/package.rb:573:in `spec'
    /opt/hostedtoolcache/Ruby/3.1.2/x64/lib/ruby/3.1.0/delegate.rb:87:in `method_missing'
    /home/runner/work/gem2rpm/gem2rpm/lib/gem2rpm.rb:83:in `print_dependencies'
    /home/runner/work/gem2rpm/gem2rpm/test/test_gem2rpm.rb:69:in `test_print_dependencies'
~~~