### PR TITLE
Test against Ruby 4.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,7 @@ jobs:
           - "3.2"
           - "3.3"
           - "3.4"
+          - "4.0"
           - "ruby-head"
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
Ruby 4.0 were release on 2025-12-25, therefore add it into test matrix.